### PR TITLE
Fix IndexError: list index out of range

### DIFF
--- a/doodstream/api.py
+++ b/doodstream/api.py
@@ -1,7 +1,6 @@
 import requests
 import re
 import sys
-import json
 
 class DoodStream:
     '''Python doodstream api wrapper from official https://doodstream.com/api
@@ -56,8 +55,7 @@ class DoodStream:
         post_data = {"api_key": self.api_key}
         filename = path.split("/")[-1]
         post_files = {"file": (filename, open(path, "rb"))}
-        up = requests.post(url_for_upload, data=post_data, files=post_files)
-        res = json.loads(up.text)
+        res = requests.post(url_for_upload, data=post_data, files=post_files).json()
         if res["msg"] == "OK":
             return res
         else:

--- a/doodstream/api.py
+++ b/doodstream/api.py
@@ -1,6 +1,7 @@
 import requests
 import re
 import sys
+import json
 
 class DoodStream:
     '''Python doodstream api wrapper from official https://doodstream.com/api
@@ -56,10 +57,9 @@ class DoodStream:
         filename = path.split("/")[-1]
         post_files = {"file": (filename, open(path, "rb"))}
         up = requests.post(url_for_upload, data=post_data, files=post_files)
-        st = re.findall(r'name="st">(.*?)</text' , str(up.text))
-        fn = re.findall(r'name="fn">(.*?)</text' , str(up.text))
-        if st[0] == "OK":
-            return {"status": st[0], "file_id": fn[0], "file_url": f"https://doodstream.com/d/{fn[0]}"}
+        res = json.loads(up.text)
+        if res["msg"] == "OK":
+            return res
         else:
             raise TypeError(f"unsupported video format {filename}, please upload video with mkv, mp4, wmv, avi, mpeg4, mpegps, flv, 3gp, webm, mov, mpg & m4v format")
         


### PR DESCRIPTION
# Description

When I ran the local_upload method
```py
d = DoodStream(DSTREAM_API_KEY)
d.local_upload(path_to_video)
```

i got an error:

Traceback (most recent call last):
  File "C:\Users\Rain Risa\Documents\rainft\rk73-telegram-client\src\functions\createvid.py", line 61, in local_upload
    if st[0] == "OK":
IndexError: list index out of range

So i create this pull request to prevent anyone else from getting the same result

# How this code works:

It will convert string response from doodstream into dict
```py
up = requests.post(url_for_upload, data=post_data, files=post_files)
res = json.loads(up.text)
```

and we can directly return it
```py
if res["msg"] == "OK":
    return res
```

The returned data will be like this:

{'msg': 'OK', 'server_time': '2022-08-01 01:06:13', 'status': 200, 'result': [{'download_url': 'https://dood.la/d/rucpsdfgt2qm', 'single_img': 'https://img.doodcdn.co/snaps/8a5abrgu5dxkfddt.jpg', 'status': 200, 'filecode': 'rucpsdfgt2qm', 'splash_img': 'https://img.doodcdn.co/splash/8a5abrgu5dxkfddt.jpg', 'canplay': 1, 'size': '467319', 'length': '19', 'uploaded': '2022-08-01 02:04:12', 'protected_embed': 'https://dood.la/e/6cj1qvqmigyyejqrfasdkrxcfgflkpuo238', 'protected_dl': 'https://dood.la/d/b6cg3xdpgrjdauysbsg54dfgbjdl44mge', 'title': 'my awesome vid'}]}

So that user can access the data with the code below:

```py
data = d.local_upload("path_to_video)

print(data["result"][0]["download_url"]) # https://dood.la/d/rucpsdfgt2qm
print(data["server_time"]) # 2022-08-01 01:06:13
print(data["msg"]) # OK
print(data["result"][0]["filecode"]) # rucp6d0gt2qm
print(data["result"][0]["title"]) # my awesome vid
```

and so on

Please note that the example response above is just an example, means you might get a 404 page when accessing the url
But you can always try with your own doodstream!

Hope this pull request can be accepted :)